### PR TITLE
Marco drop

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -363,6 +363,7 @@ fn winch_supports_module(module: &[u8]) -> bool {
                         | Loop { .. }
                         | Br { .. }
                         | BrIf { .. } => {}
+                        | Drop { .. } => {}
                         _ => {
                             supported = false;
                             break 'main;

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -119,7 +119,7 @@ where
     }
 
     fn visit_drop(&mut self) -> Self::Output {
-        self.context.stack.pop();
+        self.context.drop_last(1);
     }
 
     fn visit_i64_const(&mut self, val: i64) {

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -4,6 +4,7 @@
 //! which validates and dispatches to the corresponding
 //! machine code emitter.
 
+use crate::abi::ABI;
 use crate::codegen::CodeGen;
 use crate::codegen::ControlStackFrame;
 use crate::masm::{CmpKind, DivKind, MacroAssembler, OperandSize, RegImm, RemKind, ShiftKind};
@@ -119,6 +120,9 @@ where
     }
 
     fn visit_drop(&mut self) -> Self::Output {
+        if let Some(Val::Memory(_)) = self.context.stack.peek() {
+            self.masm.free_stack(<M as MacroAssembler>::ABI::word_bytes());
+        }
         self.context.drop_last(1);
     }
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -103,6 +103,7 @@ macro_rules! def_unsupported {
     (emit Loop $($rest:tt)*) => {};
     (emit Br $($rest:tt)*) => {};
     (emit BrIf $($rest:tt)*) => {};
+    (emit Drop $($rest:tt)*) => {};
 
     (emit $unsupported:tt $($rest:tt)*) => {$($rest)*};
 }
@@ -115,6 +116,10 @@ where
 
     fn visit_i32_const(&mut self, val: i32) {
         self.context.stack.push(Val::i32(val));
+    }
+
+    fn visit_drop(&mut self) -> Self::Output {
+        self.context.stack.pop();
     }
 
     fn visit_i64_const(&mut self, val: i64) {

--- a/winch/filetests/filetests/x64/drop/simple.wat
+++ b/winch/filetests/filetests/x64/drop/simple.wat
@@ -2,9 +2,9 @@
 
 (module
     (func (result i32)
-	(i32.const 10)
-	(i32.const 20)
-    (i32.const 30)
+	(i32.const 1)
+	(i32.const 2)
+    (i32.const 3)
     (drop)
 	(i32.add)
     )
@@ -13,8 +13,8 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 b80a000000           	mov	eax, 0xa
-;;   11:	 83c014               	add	eax, 0x14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 83c002               	add	eax, 2
 ;;   14:	 4883c408             	add	rsp, 8
 ;;   18:	 5d                   	pop	rbp
-;;   19:	 c3                   	ret
+;;   19:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/drop/simple.wat
+++ b/winch/filetests/filetests/x64/drop/simple.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+	(i32.const 10)
+	(i32.const 20)
+    (i32.const 30)
+    (drop)
+	(i32.add)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b80a000000           	mov	eax, 0xa
+;;   11:	 83c014               	add	eax, 0x14
+;;   14:	 4883c408             	add	rsp, 8
+;;   18:	 5d                   	pop	rbp
+;;   19:	 c3                   	ret

--- a/winch/filetests/filetests/x64/drop/with_blocks.wat
+++ b/winch/filetests/filetests/x64/drop/with_blocks.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+	(i32.const 1)
+    (i32.const 2)
+	(block (result i32)
+        (i32.const 3)
+    )
+    (drop)
+	(i32.add)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c003000000       	mov	rax, 3
+;;   13:	 b801000000           	mov	eax, 1
+;;   18:	 83c002               	add	eax, 2
+;;   1b:	 4883c408             	add	rsp, 8
+;;   1f:	 5d                   	pop	rbp
+;;   20:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/drop/with_call.wat
+++ b/winch/filetests/filetests/x64/drop/with_call.wat
@@ -1,0 +1,33 @@
+;;! target = "x86_64"
+
+(module
+    (func $answer (result i32) (i32.const 42))
+    (func (result i32)
+	(i32.const 1)
+	(i32.const 2)
+    (call $answer)
+    (drop)
+	(i32.add)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c02a000000       	mov	rax, 0x2a
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 b801000000           	mov	eax, 1
+;;   1e:	 83c002               	add	eax, 2
+;;   21:	 4883c408             	add	rsp, 8
+;;   25:	 5d                   	pop	rbp
+;;   26:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/drop/with_if.wat
+++ b/winch/filetests/filetests/x64/drop/with_if.wat
@@ -1,0 +1,49 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "as-if-condition") (param i32) (result i32)
+    (i32.const 1)
+	(i32.const 2)
+    (if (result i32)
+      (if (result i32) (local.get 0)
+        (then (i32.const 1)) (else (i32.const 0))
+      )
+      (then (call $dummy) (i32.const 2))
+      (else (call $dummy) (i32.const 3))
+    )
+    (drop)
+    (i32.add)
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   15:	 85c0                 	test	eax, eax
+;;   17:	 0f840c000000         	je	0x29
+;;   1d:	 48c7c001000000       	mov	rax, 1
+;;   24:	 e907000000           	jmp	0x30
+;;   29:	 48c7c000000000       	mov	rax, 0
+;;   30:	 85c0                 	test	eax, eax
+;;   32:	 0f8411000000         	je	0x49
+;;   38:	 e800000000           	call	0x3d
+;;   3d:	 48c7c002000000       	mov	rax, 2
+;;   44:	 e90c000000           	jmp	0x55
+;;   49:	 e800000000           	call	0x4e
+;;   4e:	 48c7c003000000       	mov	rax, 3
+;;   55:	 b801000000           	mov	eax, 1
+;;   5a:	 83c002               	add	eax, 2
+;;   5d:	 4883c410             	add	rsp, 0x10
+;;   61:	 5d                   	pop	rbp
+;;   62:	 c3                   	ret	


### PR DESCRIPTION
# Why? 

Implement the drop instruction for winch

# how?

the `CodeGenContext` already had a function to drop values from the stack, so I just used that and called it with `1`.

I hope I have also added `drop` as a supported tag in all places that I should have.

# testing

I've added 4 filetests and I've run fuzzing for few minutes with `FUZZ_WINCH=1 ALLOWED_ENGINES=wasmi ALLOWED_MODULES=wasm-smith cargo fuzz run differential` while on the same nightly version as the one specified in the github actions, namely `nightly-2023-03-20`